### PR TITLE
ft_export() 함수 업데이트

### DIFF
--- a/srcs/builtins/ft_export.c
+++ b/srcs/builtins/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/07 18:11:19 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/08 22:55:42 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/10 15:01:34 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,9 @@ static int	export_only(t_env *env_list)
 	curr = env_list;
 	while (curr)
 	{
-		if (curr->value)
+		if (!ft_strncmp(curr->key, "?", 1))
+			;
+		else if (curr->value)
 			printf("declare -x %s=\"%s\"\n", curr->key, curr->value);
 		else
 			printf("declare -x %s\n", curr->key);


### PR DESCRIPTION
- export 명령어가 단독으로 사용되었을 때에 환경변수 리스트 중 $? 를 출력하지 않도록 추가