### PR TITLE
Refactor ft_unset

### DIFF
--- a/srcs/builtins/ft_unset.c
+++ b/srcs/builtins/ft_unset.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/12 23:27:30 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/13 02:44:21 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/13 18:58:47 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@ int	ft_unset(char **cmds, t_data *data)
 	int		i;
 
 	i = 0;
+	ret = SUCCESS;
 	while (cmds[++i])
 	{
 		if (!is_valid_key_name(cmds[i]))
@@ -31,7 +32,6 @@ int	ft_unset(char **cmds, t_data *data)
 			node = get_node_with_key(data, cmds[i]);
 			if (node)
 				remove_node(node);
-			ret = SUCCESS;
 		}
 	}
 	return (ret);


### PR DESCRIPTION
- unset 의 인자가 여러개 들어오는 경우 하나라도 에러가 발생하면 FAILURE 를 반환하도록 변경
- 변경 전에는 마지막 인자에 대한 성공/실패의 여부가 반환되었으나, 변경 후에는 어느 위치의 인자든 상관 없이 에러가 발생하면 FAILURE
- 해당 인자가 환경변수 리스트에 존재하든 아니든 상관 없이 유효한 키 이름이기만 하면 성공을 반환함