### PR TITLE
Remove '_' in is_valid_key_name (#6)

### DIFF
--- a/srcs/builtins/utils.c
+++ b/srcs/builtins/utils.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/12 23:38:55 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/13 19:04:03 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/13 19:15:32 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,6 @@ int	is_valid_key_name(char *key)
 	if (ft_isdigit(key[0]))
 		return (FALSE);
 	if (ft_strchr(key, '?'))
-		return (FALSE);
-	if (key[0] == '_')
 		return (FALSE);
 	return (TRUE);
 }


### PR DESCRIPTION
- 환경변수 키이름이 _ 인 경우 에러가 아니라 단순히 환경변수 값을 바꾸지 않도록 무시되는 것이기 때문에 해당 함수에서 삭제