### PR TITLE
명령어 파싱 - AST 정리

### DIFF
--- a/includes/parsing.h
+++ b/includes/parsing.h
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/08 19:17:43 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/14 21:25:58 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/14 21:42:01 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,12 @@
 int		parse_env(char **envp, t_data *data);
 
 int		tokenize(t_data *data, char *line);
-
 int		trim_token(t_data *data);
-
 int		expand_env(t_data *data, t_token *curr);
 
 int		create_astree(t_data *data);
 t_ast	*create_ast_node(t_token *curr);
-
 t_ast	*add_ast_node(t_ast *parent, t_ast *new);
+int		simplify_astree(t_ast *node);
 
 #endif

--- a/srcs/parsing/ast.c
+++ b/srcs/parsing/ast.c
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/13 17:27:32 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/14 00:53:08 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/14 22:07:02 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,26 +15,26 @@
 // 나중에 삭제
 // void	display_astree(t_ast *ast)
 // {
+// 	int	i;
+
 // 	if (!ast)
 // 		return ;
 // 	printf("=== %s ===\n", ast->token ? ast->token : "PL");
 // 	printf("(L) %s | ", ast->left ? (ast->left->token ? ast->left->token : "PL") : "NULL");
 // 	printf("(R) %s\n", ast->right ? (ast->right->token ? ast->right->token : "PL") : "NULL");
+// 	if (ast->argc)
+// 	{
+// 		i = 0;
+// 		printf("argv: ");
+// 		while ((ast->argv)[i])
+// 			printf("|%s|\t", (ast->argv)[i++]);
+// 		printf("\n");
+// 	}
 // 	if (!ast->left && !ast->right)
 // 		printf("-----------------\n");
 // 	display_astree(ast->left);
 // 	display_astree(ast->right);
 // }
-
-void	free_astree(t_data *data, t_ast *ast)
-{
-	if (!ast)
-		return ;
-	free_astree(data, ast->left);
-	free_astree(data, ast->right);
-	free(ast);
-	data->astree = NULL;
-}
 
 static void	set_token_type(t_ast *node, int is_word)
 {
@@ -81,13 +81,12 @@ int	create_astree(t_data *data)
 		new = create_ast_node(curr);
 		root = add_ast_node(data->astree, new);
 		if (!root)
-		{
-			free_astree(data, data->astree);
 			return (FALSE);
-		}
 		data->astree = root;
 		curr = curr->next;
 	}
+	if (!simplify_astree(data->astree))
+		return (FALSE);
 	// display_astree(data->astree);
 	// printf("\n");
 	return (TRUE);

--- a/srcs/parsing/ast_simplify.c
+++ b/srcs/parsing/ast_simplify.c
@@ -6,8 +6,68 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/14 21:37:31 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/14 21:38:45 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/14 22:04:44 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static int	init_ast_argv(t_ast *node, int len)
+{
+	node->argc = len;
+	node->argv = (char **)ft_calloc(len + 1, sizeof(char *));
+	if (!node->argv)
+		return (FALSE);
+	(node->argv)[0] = ft_strdup(node->token);
+	if (!(node->argv)[0])
+		return (FALSE);
+	return (TRUE);
+}
+
+static int	merge_cmd_node(t_ast *node)
+{
+	int	i;
+
+	if (!node->right)
+	{
+		if (!init_ast_argv(node, 1))
+			return (FALSE);
+		return (TRUE);
+	}
+	if (!merge_cmd_node(node->right))
+		return (FALSE);
+	if (!init_ast_argv(node, node->right->argc + 1))
+		return (FALSE);
+	i = 0;
+	while (++i < node->argc)
+	{
+		(node->argv)[i] = ft_strdup(node->right->argv[i - 1]);
+		if (!(node->argv)[i])
+			return (FALSE);
+	}
+	free_astree(node->right);
+	node->right = NULL;
+	return (TRUE);
+}
+
+int	simplify_astree(t_ast *node)
+{
+	int	result;
+
+	result = TRUE;
+	if (node->type < T_PL)
+		return (TRUE);
+	if (node->type == T_PL)
+	{
+		if (node->right)
+			result = merge_cmd_node(node->right);
+	}
+	else
+	{
+		result = simplify_astree(node->left);
+		if (!result)
+			return (FALSE);
+		result = simplify_astree(node->right);
+	}
+	return (result);
+}


### PR DESCRIPTION
🥳  **(경)** 파싱지옥 탈출 **(축)** 🥳

1. AST의 CMD 노드에 argc, argv 세팅 (추후 `execve` 실행 시 필요)
2. CMD 노드에 옵션이나 인자 자식 노드가 있는 경우 부모 노드로 병합