### PR TITLE
Fix ft_strncmp() to ft_strcmp()

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -12,7 +12,7 @@ SRCS = ft_strdup.c \
 		ft_strchr.c \
 		ft_substr.c \
 		ft_isspace.c \
-		ft_strncmp.c \
+		ft_strcmp.c \
 		ft_strjoin.c
 OBJS = $(SRCS:.c=.o)
 

--- a/libft/ft_strcmp.c
+++ b/libft/ft_strcmp.c
@@ -1,18 +1,18 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_strncmp.c                                       :+:      :+:    :+:   */
+/*   ft_strcmp.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/10 12:27:14 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/10 12:27:23 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/15 15:44:27 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-int	ft_strncmp(const char *s1, const char *s2, size_t n)
+int	ft_strcmp(const char *s1, const char *s2)
 {
 	size_t			i;
 	unsigned char	*str1;
@@ -21,11 +21,7 @@ int	ft_strncmp(const char *s1, const char *s2, size_t n)
 	str1 = (unsigned char *)s1;
 	str2 = (unsigned char *)s2;
 	i = 0;
-	while (n--)
-	{
-		if (str1[i] != str2[i] || !str1[i] || !str2[i])
-			return (str1[i] - str2[i]);
+	while (str1[i] != str2[i] || !str1[i] ||| !str2[i])
 		++i;
-	}
-	return (0);
+	return (str1[i] - str2[i]);
 }

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -12,7 +12,7 @@ void	*ft_calloc(size_t count, size_t size);
 char	*ft_strchr(const char *s, int c);
 char	*ft_substr(char const *s, unsigned int start, size_t len);
 int		ft_isspace(int c);
-int		ft_strncmp(const char *s1, const char *s2, size_t n);
+int		ft_strcmp(const char *s1, const char *s2);
 char	*ft_strjoin(char const *s1, char const *s2);
 
 #endif


### PR DESCRIPTION
[#84](https://github.com/S0YKIM/42-MINISHELL/issues/84) 의 오류를 해결하기 위해 문자열 비교 함수를 n 개만 비교하는 것이 아니라 전체를 비교하도록 수정하였습니다.