### PR TITLE
Remove ft_strncmp() (#6)

### DIFF
--- a/srcs/builtins/ft_env.c
+++ b/srcs/builtins/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/06 18:53:17 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/15 15:52:50 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/15 15:54:13 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ int	ft_env(char **cmds, t_data *data)
 	curr = data->env_list;
 	while (curr)
 	{
-		if (curr->key == '?')
+		if (*(curr->key) == '?')
 		{
 			curr = curr->next;
 			continue ;


### PR DESCRIPTION
ft_strncmp() 를 이용해 환경변수 키가 ? 인지 확인하던 부분을 *(curr->key) == '?' 인지 직접 비교하도록 변경