### PR TITLE
Add line to ignore unsetting '_' (#6)

### DIFF
--- a/srcs/builtins/ft_unset.c
+++ b/srcs/builtins/ft_unset.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/12 23:27:30 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/19 13:18:17 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/19 13:43:42 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ int	ft_unset(t_ast *ast, t_data *data)
 			not a valid identifier\n", ast->argv[i]);
 			ret = FAILURE;
 		}
-		else
+		else if (*(ast->argv[i]) != '_')
 		{
 			node = get_node_with_key(data, ast->argv[i]);
 			if (node)


### PR DESCRIPTION
ft_export() 에서는 export _=123 와 같이 '_' 환경변수를 변경하지 못하도록 방지하였는데 ft_unset() 에서는 하지 않았기 때문에 추가하였습니다.