### PR TITLE
Fix expanding env to handle edge cases (#3 #13 #7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+         #
+#    By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/04/18 16:05:23 by heehkim           #+#    #+#              #
-#    Updated: 2022/04/22 23:29:04 by sokim            ###   ########.fr        #
+#    Updated: 2022/04/23 17:52:37 by heehkim          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -39,6 +39,7 @@ SRC_LIST = main.c \
 			$(D_PARSING)token.c \
 			$(D_PARSING)trim.c \
 			$(D_PARSING)expand.c \
+			$(D_PARSING)expand_env_value.c \
 			$(D_PARSING)ast.c \
 			$(D_PARSING)ast_add.c \
 			$(D_PARSING)ast_simplify.c \

--- a/includes/parsing.h
+++ b/includes/parsing.h
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/08 19:17:43 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/21 23:02:18 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/23 17:53:15 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@ int		parse_env(char **envp);
 int		tokenize(t_data *data, char *line);
 int		trim_token(t_data *data);
 int		expand_env(t_token *curr);
+char	*expand_env_value(char *i, char **key_end, int is_dquote);
 
 int		create_astree(t_data *data);
 t_ast	*create_ast_node(t_token *curr);

--- a/srcs/parsing/expand_env_value.c
+++ b/srcs/parsing/expand_env_value.c
@@ -1,0 +1,82 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_env_value.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/04/23 17:52:23 by heehkim           #+#    #+#             */
+/*   Updated: 2022/04/23 17:59:29 by heehkim          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	is_valid_key_char(char c)
+{
+	if (!ft_isalpha(c) && c != '_')
+		return (FALSE);
+	return (TRUE);
+}
+
+static char	*expand_env_value_exception(char *i, char **key_end)
+{
+	char	*tmp;
+
+	if (!**key_end)
+		return (ft_strdup("$"));
+	tmp = ft_strchr(*key_end, '\"');
+	if (tmp)
+		*key_end = tmp - 1;
+	else
+		(*key_end)--;
+	return (ft_substr(i, 0, *key_end - i + 1));
+}
+
+static char	*join_dquote_str(char **key_end, char *value)
+{
+	char	*str_end;
+	char	*tail;
+	char	*tmp;
+
+	str_end = ft_strchr(*key_end + 1, '\"') - 1;
+	if (str_end == *key_end)
+		return (value);
+	tail = ft_substr(*key_end + 1, 0, str_end - *key_end);
+	if (!tail)
+		return (NULL);
+	tmp = value;
+	value = ft_strjoin(value, tail);
+	free(tmp);
+	free(tail);
+	*key_end = str_end;
+	return (value);
+}
+
+char	*expand_env_value(char *i, char **key_end, int is_dquote)
+{
+	char	*key_start;
+	char	*key;
+	char	*value;
+
+	key_start = i + 1;
+	*key_end = key_start;
+	if (**key_end != '?' && !is_valid_key_char(**key_end))
+		return (expand_env_value_exception(i, key_end));
+	while (**key_end)
+	{
+		if (**key_end == '?')
+			break ;
+		if (!*(*key_end + 1) || !is_valid_key_char(*(*key_end + 1)))
+			break ;
+		(*key_end)++;
+	}
+	key = ft_substr(key_start, 0, *key_end - key_start + 1);
+	if (!key)
+		return (NULL);
+	value = get_env_value(key);
+	free(key);
+	if (is_dquote)
+		return (join_dquote_str(key_end, value));
+	return (value);
+}


### PR DESCRIPTION
`$??` => 0?
`"$USER na"me` => heehkim name
`$USER---` => heehkim---

위 케이스처럼 환경변수명 규칙에 부합하는 부분까지만 치환하고 이후 문자열은 문자취급하도록 수정하였습니다.