### PR TITLE
Fix expanding env to handle key including nums (#7)

### DIFF
--- a/srcs/parsing/expand_env_value.c
+++ b/srcs/parsing/expand_env_value.c
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/23 17:52:23 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/23 17:59:29 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/23 18:08:31 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 static int	is_valid_key_char(char c)
 {
-	if (!ft_isalpha(c) && c != '_')
+	if (!ft_isdigit(c) && !ft_isalpha(c) && c != '_')
 		return (FALSE);
 	return (TRUE);
 }
@@ -61,7 +61,7 @@ char	*expand_env_value(char *i, char **key_end, int is_dquote)
 
 	key_start = i + 1;
 	*key_end = key_start;
-	if (**key_end != '?' && !is_valid_key_char(**key_end))
+	if (**key_end != '?' && !ft_isalpha(**key_end) && **key_end != '_')
 		return (expand_env_value_exception(i, key_end));
 	while (**key_end)
 	{


### PR DESCRIPTION
환경변수 키값에 숫자가 들어가는 케이스 대응
1. 첫 번째 문자가 숫자인 경우 유효하지 않은 키로 판단하여 일반 문자로 해석
2. 이후 문자에 숫자가 포함된 경우 유효한 키로 판단하여 치환