### PR TITLE
Add ignoring signal when another minishell program executed (#103)

### DIFF
--- a/srcs/pipe/fork.c
+++ b/srcs/pipe/fork.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/19 17:19:46 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/25 19:05:02 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/25 20:20:13 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,14 +49,18 @@ static void	child(t_data *data, int i)
 	else if (i != 0)
 		dup_fd(curr->pipe_fd[WRITE], STDOUT_FILENO);
 	close_child_fds(in_fd, out_fd, curr, prev);
-	set_signal();
 	execute_cmd(curr->right, data);
 }
 
-static int	parent(int pid)
+static int	parent(int pid, char *cmd)
 {
 	int	status;
 
+	if (!ft_strcmp("./minishell", cmd))
+	{
+		signal(SIGINT, SIG_IGN);
+		signal(SIGQUIT, SIG_IGN);
+	}
 	if (waitpid(pid, &status, 0) == ERROR)
 		return (FALSE);
 	if (WIFEXITED(status))
@@ -71,8 +75,6 @@ int	fork_process(t_data *data)
 	pid_t	pid;
 	int		i;
 
-	signal(SIGINT, SIG_IGN);
-	signal(SIGQUIT, SIG_IGN);
 	if (data->curr_pl >= data->pl_cnt)
 		return (TRUE);
 	i = (data->curr_pl)++;
@@ -87,5 +89,5 @@ int	fork_process(t_data *data)
 			return (FALSE);
 		child(data, i);
 	}
-	return (parent(pid));
+	return (parent(pid, data->token_list->data));
 }


### PR DESCRIPTION
아까 시그널 무시하도록 추가한 코드 때문에 오류 나는게 마음에 걸려서 결국 오늘 처리해버렸습니다...
./minishell ./minishell 처럼 미니쉘 안에서 미니쉘이 실행되는 경우 부모 미니쉘에서 시그널을 껐다가 자식 미니쉘이 종료되면 다시 켜도록 변경하고 기존의 코드는 삭제하였더니 잘 작동하네요~
이제는 진짜 시험 공부를...제발! 