### PR TITLE
Remove read_fd from heredoc.c (#3)

### DIFF
--- a/includes/pipe.h
+++ b/includes/pipe.h
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 15:50:33 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/24 15:12:44 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/26 01:01:57 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,5 @@ int		open_infile(char *path);
 int		open_outfile(char *path, int flag);
 void	close_fd(int fd);
 void	dup_fd(int fd1, int fd2);
-
-// 나중에 삭제
-void	read_fd(int fd);
 
 #endif

--- a/srcs/pipe/heredoc.c
+++ b/srcs/pipe/heredoc.c
@@ -3,31 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 16:02:56 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/25 18:23:54 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/26 01:01:44 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-// 나중에 지우기
-void	read_fd(int fd)
-{
-	int		n;
-	char	*line;
-
-	line = (char *)malloc(sizeof(char) + 1);
-	while ((n = read(fd, line, 1)) > 0)
-	{
-		printf("n: %d\n", n);
-		line[n] = '\0';
-		printf("|%s|", line);
-	}
-	free(line);
-	printf("\n");
-}
 
 static void	read_heredoc_child(t_ast *ast, int fd)
 {


### PR DESCRIPTION
테스트를 위해 필요했던 `read_fd` 함수를 더이상 사용할 일이 없을 것 같아 삭제하였습니다.