### PR TITLE
Fix error waiting input with unclosed pipes (#167)

### DIFF
--- a/srcs/pipe/execute.c
+++ b/srcs/pipe/execute.c
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/24 15:10:41 by heehkim           #+#    #+#             */
-/*   Updated: 2022/04/25 15:43:08 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/04/26 00:19:03 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,13 @@ static void	create_pl_list(t_data *data, t_ast *ast)
 {
 	if (!ast || ast->type < T_PL)
 		return ;
-	create_pl_list(data, ast->right);
-	create_pl_list(data, ast->left);
 	if (ast->type == T_PL)
 	{
 		(data->pl_list)[data->curr_pl] = ast;
 		(data->curr_pl)++;
 	}
+	create_pl_list(data, ast->left);
+	create_pl_list(data, ast->right);
 }
 
 int	execute(t_data *data)
@@ -39,5 +39,8 @@ int	execute(t_data *data)
 		return (result);
 	if (data->pl_cnt == 1 && exec_builtin(data->pl_list[0]->right, data))
 		return (TRUE);
+	data->pids = (int *)ft_calloc(data->pl_cnt, sizeof(int));
+	if (!data->pids)
+		return (FALSE);
 	return (fork_process(data));
 }


### PR DESCRIPTION
하... 결국 해결하고 자러 갑니다...

1. 재귀 포크를 위해 거꾸로 된 순서였던 `pl_list`를 먼저 실행할 명령어가 앞에 오도록 변경 (전위순회)
2. `fork_process`에서는 반복문을 돌면서 순차적으로 포크하고, 포크 반복문이 끝나면 각 자식 프로세스를 한꺼번에 대기하도록 변경
3. `parent`에서 쓰지 않는 파이프를 미리 닫아주도록 변경
(자식에서 닫아줬다고 부모에서도 닫기는 게 아니기 때문에 미리 닫지 않으면 뒤로 갈수록 닫히지 않은 파이프를 주렁주렁 달고 있음..)
4. `close_child_fds`에서 쓰고난 파이프와 쓰지 않은 파이프 모두 닫아주도록 변경
(현재 자식 프로세스는 이전의 자식 프로세스와 다른 독립적인 프로세스기 때문에 앞과 현재 파이프 모두 여기서 다 닫아줬어야 함!)