### PR TITLE
Fix error expanding env which value is NULL (#177)

### DIFF
--- a/srcs/env/get.c
+++ b/srcs/env/get.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/10 13:42:35 by sokim             #+#    #+#             */
-/*   Updated: 2022/04/22 22:04:56 by sokim            ###   ########.fr       */
+/*   Updated: 2022/04/27 18:10:20 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,11 @@ char	*get_env_value(char *key)
 	while (curr)
 	{
 		if (!ft_strcmp(curr->key, key))
+		{
+			if (!curr->value)
+				return (ft_strdup(""));
 			return (ft_strdup(curr->value));
+		}
 		curr = curr->next;
 	}
 	return (ft_strdup(""));


### PR DESCRIPTION
밸류가 NULL인 환경변수를 치환할 때 오류로 인식하여 종료되는 문제 해결
- 기존에 get_env_value`에서 키는 존재하지만 밸류가 NULL인 경우에도 NULL을 반환
- `ft_strdup`에서 오류가 난 경우와 구분되지 않음
👉 밸류가 NULL인 경우 빈 문자열을 복사하여 반환하도록 수정